### PR TITLE
Use built-in path module instead of dogmatic version

### DIFF
--- a/packages/expected-fs/__tests__/unit/FileWrapper/equalToFile.js
+++ b/packages/expected-fs/__tests__/unit/FileWrapper/equalToFile.js
@@ -8,7 +8,7 @@ const {
 
 const expected = _core.dogma.use(require("@akromio/expected"));
 
-const path = _core.dogma.use(require("@dogmalang/path"));
+const path = _core.dogma.use(require("path"));
 
 suite(__filename, () => {
   {

--- a/packages/expected-fs/dist/cjs/DirWrapper.js
+++ b/packages/expected-fs/dist/cjs/DirWrapper.js
@@ -2,7 +2,7 @@
 
 var _core = require("@dogmalang/core");
 
-const path = _core.dogma.use(require("@dogmalang/path"));
+const path = _core.dogma.use(require("path"));
 
 const fs = _core.dogma.use(require("@dogmalang/fs.sync"));
 

--- a/packages/expected-fs/dist/cjs/FileWrapper.js
+++ b/packages/expected-fs/dist/cjs/FileWrapper.js
@@ -2,8 +2,6 @@
 
 var _core = require("@dogmalang/core");
 
-const path = _core.dogma.use(require("@dogmalang/path"));
-
 const fs = _core.dogma.use(require("@dogmalang/fs.sync"));
 
 const AssertionError = _core.dogma.use(require("./AssertionError"));

--- a/packages/expected-fs/dist/cjs/FilesWrapper.js
+++ b/packages/expected-fs/dist/cjs/FilesWrapper.js
@@ -2,8 +2,6 @@
 
 var _core = require("@dogmalang/core");
 
-const path = _core.dogma.use(require("@dogmalang/path"));
-
 const fs = _core.dogma.use(require("@dogmalang/fs.sync"));
 
 const {

--- a/packages/expected-fs/dist/cjs/index.js
+++ b/packages/expected-fs/dist/cjs/index.js
@@ -4,7 +4,7 @@ var _core = require("@dogmalang/core");
 
 const pkg = _core.dogma.use(require("../../package"));
 
-const path = _core.dogma.use(require("@dogmalang/path"));
+const path = _core.dogma.use(require("path"));
 
 const DirWrapper = _core.dogma.use(require("./DirWrapper"));
 

--- a/packages/expected-fs/package-lock.json
+++ b/packages/expected-fs/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dogmalang/core": "^1.0.0-rc18.0",
-        "@dogmalang/fs.sync": "^0.2.0",
-        "@dogmalang/path": "^0.1.0"
+        "@dogmalang/fs.sync": "^0.2.0"
       },
       "engines": {
         "node": ">= 14",

--- a/packages/expected-fs/package.json
+++ b/packages/expected-fs/package.json
@@ -40,8 +40,7 @@
   "dependencies": {
     "@akromio/expected-helpers": "^0.1.0",
     "@dogmalang/core": "^1.0.0-rc18.0",
-    "@dogmalang/fs.sync": "^0.2.0",
-    "@dogmalang/path": "^0.1.0"
+    "@dogmalang/fs.sync": "^0.2.0"
   },
   "devDependencies": {
     "@akromio/expected": "^0.1.0"

--- a/packages/expected-fs/src/DirWrapper.dog
+++ b/packages/expected-fs/src/DirWrapper.dog
@@ -1,5 +1,5 @@
 use (
-  alias://path
+  dep://path
   alias://fs
   AssertionError
 )

--- a/packages/expected-fs/src/FileWrapper.dog
+++ b/packages/expected-fs/src/FileWrapper.dog
@@ -1,5 +1,4 @@
 use (
-  alias://path
   alias://fs
   AssertionError
 )

--- a/packages/expected-fs/src/FilesWrapper.dog
+++ b/packages/expected-fs/src/FilesWrapper.dog
@@ -1,5 +1,4 @@
 use (
-  alias://path
   alias://fs
   {color} = alias://helpers
   AssertionError

--- a/packages/expected-fs/src/index.dog
+++ b/packages/expected-fs/src/index.dog
@@ -1,6 +1,6 @@
 use (
   pkg = ../../package
-  alias://path
+  dep://path
   DirWrapper
   FileWrapper
   FilesWrapper

--- a/packages/expected-fs/tests/unit/FileWrapper/equalToFile.dog
+++ b/packages/expected-fs/tests/unit/FileWrapper/equalToFile.dog
@@ -1,7 +1,7 @@
 use (
   {AssertionError} = dep://assert
   alias://expected
-  alias://path
+  dep://path
 )
 
 suite(__filename, proc()

--- a/packages/expected/__tests__/unit/index.js
+++ b/packages/expected/__tests__/unit/index.js
@@ -2,7 +2,7 @@
 
 var _core = require("@dogmalang/core");
 
-const path = _core.dogma.use(require("@dogmalang/path"));
+const path = _core.dogma.use(require("path"));
 
 const {
   assert

--- a/packages/expected/package-lock.json
+++ b/packages/expected/package-lock.json
@@ -13,9 +13,6 @@
         "lodash.get": "^4.4.2",
         "uuid": "^8.3.2"
       },
-      "devDependencies": {
-        "@dogmalang/path": "^0.1.0"
-      },
       "engines": {
         "node": ">= 14",
         "npm": ">= 6"
@@ -34,19 +31,6 @@
       "engines": {
         "node": ">= 10.0.0",
         "npm": ">= 6.0.0"
-      }
-    },
-    "node_modules/@dogmalang/path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dogmalang/path/-/path-0.1.0.tgz",
-      "integrity": "sha512-r8ocnRxwM/AbWXuWOgLHGdzQfkcBu9KpHLbCpVtwSGsPXydmYmzYqSYKZLEvks2XwRnriL51Y5FWoRGy8nU2gw==",
-      "dev": true,
-      "dependencies": {
-        "@dogmalang/core": "*"
-      },
-      "engines": {
-        "node": ">= 8.0",
-        "npm": ">= 3.10"
       }
     },
     "node_modules/@dogmalang/time.converter": {
@@ -628,15 +612,6 @@
         "deep-equal": "^2.0.4",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2"
-      }
-    },
-    "@dogmalang/path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dogmalang/path/-/path-0.1.0.tgz",
-      "integrity": "sha512-r8ocnRxwM/AbWXuWOgLHGdzQfkcBu9KpHLbCpVtwSGsPXydmYmzYqSYKZLEvks2XwRnriL51Y5FWoRGy8nU2gw==",
-      "dev": true,
-      "requires": {
-        "@dogmalang/core": "*"
       }
     },
     "@dogmalang/time.converter": {

--- a/packages/expected/package.json
+++ b/packages/expected/package.json
@@ -45,9 +45,6 @@
     "lodash.get": "^4.4.2",
     "uuid": "^8.3.2"
   },
-  "devDependencies": {
-    "@dogmalang/path": "^0.1.0"
-  },
   "scripts": {
     "lint": "dogmac check src tests && tsc src/index.d.ts",
     "build": "npm run build/src",

--- a/packages/expected/tests/unit/index.dog
+++ b/packages/expected/tests/unit/index.dog
@@ -1,5 +1,5 @@
 use (
-  alias://path
+  dep://path
   {assert} = dep://chai
   expected = ~
 )


### PR DESCRIPTION
We are using the dogmatic version for the path module (@dogmalang/path). We have to remove it and use the built-in module.